### PR TITLE
ci: optimize the docker verification process per change path

### DIFF
--- a/.github/workflows/dockerfiles_ci.yml
+++ b/.github/workflows/dockerfiles_ci.yml
@@ -16,21 +16,27 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Determine changed paths
-        id: changed-paths
-        run: |
-          # Get the list of changed paths
-          changed_paths=$(git diff --name-only | grep -E '^dockerfiles/|\.github/workflows/dockerfiles_ci\.yml$' || true)
-          echo "Changed paths: $changed_paths"
-          echo "::set-output name=changed-paths::$changed_paths"
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v42
+        # To compare changes between the current commit and the last pushed remote commit set `since_last_remote_commit: true`. e.g
+        # with:
+        #   since_last_remote_commit: true 
 
+      - name: List all changed files
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
+        run: |
+          for file in ${ALL_CHANGED_FILES}; do
+            echo "$file was changed"
+          done
       - name: Build Docker image
         run: |
           # Split the changed paths into an array
           IFS=$'\n' read -r -a paths_array <<< "${{ steps.changed-paths.outputs.changed-paths }}"
 
           # Build all Dockerfile directories if workflow file is changed
-          for path in "${paths_array[@]}"; do
+          for path in ${ALL_CHANGED_FILES}; do
             if [[ $path == '.github/workflows/dockerfiles_ci.yml' ]]; then
               for folder in dockerfiles/*; do
                 if [ -d "$folder" ]; then
@@ -44,7 +50,7 @@ jobs:
           done
 
           # Build only changed Dockerfile directories
-          for folder in "${paths_array[@]}"; do
+          for folder in ${ALL_CHANGED_FILES}; do
             if [ -d "$folder" ]; then
               echo "Building $folder ..."
               folder_name=$(basename "$folder")

--- a/.github/workflows/dockerfiles_ci.yml
+++ b/.github/workflows/dockerfiles_ci.yml
@@ -21,38 +21,29 @@ jobs:
         uses: tj-actions/changed-files@v42
         # To compare changes between the current commit and the last pushed remote commit set `since_last_remote_commit: true`. e.g
         # with:
-        #   since_last_remote_commit: true 
+        #   since_last_remote_commit: true
 
-      - name: List all changed files
-        env:
-          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
-        run: |
-          for file in ${ALL_CHANGED_FILES}; do
-            echo "$file was changed"
-          done
       - name: Build Docker image
         env:
           ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
-          # Build all Dockerfile directories if workflow file is changed
-          for path in ${ALL_CHANGED_FILES}; do
-            if [[ $path == '.github/workflows/dockerfiles_ci.yml' ]]; then
-              for folder in dockerfiles/*; do
-                if [ -d "$folder" ]; then
-                  echo "Building $folder ..."
-                  folder_name=$(basename "$folder")
-                  docker build -t "$folder_name" "$folder"
-                fi
-              done
-              exit 0
-            fi
-          done
-
-          # Build only changed Dockerfile directories
-          for folder in ${ALL_CHANGED_FILES}; do
-            if [ -d "$folder" ]; then
-              echo "Building $folder ..."
-              folder_name=$(basename "$folder")
-              docker build -t "$folder_name" "$folder"
-            fi
-          done
+          # Check if there is a change in the workflow file
+          if [[ $(grep -c '.github/workflows/dockerfiles_ci.yml' <<< "$ALL_CHANGED_FILES") -gt 0 ]]; then
+            # Case 1: Build all Dockerfile directories if workflow file is changed
+            for folder in dockerfiles/*; do
+              if [ -d "$folder" ]; then
+                echo "Building $folder ..."
+                folder_name=$(basename "$folder")
+                docker build -t "$folder_name" "$folder"
+              fi
+            done
+          else
+            # Case 2: Build only changed Dockerfile directories
+            for folder in ${ALL_CHANGED_FILES}; do
+              if [ -d "$folder" ]; then
+                echo "Building $folder ..."
+                folder_name=$(basename "$folder")
+                docker build -t "$folder_name" "$folder"
+              fi
+            done
+          fi

--- a/.github/workflows/dockerfiles_ci.yml
+++ b/.github/workflows/dockerfiles_ci.yml
@@ -31,6 +31,8 @@ jobs:
             echo "$file was changed"
           done
       - name: Build Docker image
+        env:
+          ALL_CHANGED_FILES: ${{ steps.changed-files.outputs.all_changed_files }}
         run: |
           # Build all Dockerfile directories if workflow file is changed
           for path in ${ALL_CHANGED_FILES}; do

--- a/.github/workflows/dockerfiles_ci.yml
+++ b/.github/workflows/dockerfiles_ci.yml
@@ -32,9 +32,6 @@ jobs:
           done
       - name: Build Docker image
         run: |
-          # Split the changed paths into an array
-          IFS=$'\n' read -r -a paths_array <<< "${{ steps.changed-paths.outputs.changed-paths }}"
-
           # Build all Dockerfile directories if workflow file is changed
           for path in ${ALL_CHANGED_FILES}; do
             if [[ $path == '.github/workflows/dockerfiles_ci.yml' ]]; then

--- a/.github/workflows/dockerfiles_ci.yml
+++ b/.github/workflows/dockerfiles_ci.yml
@@ -20,7 +20,7 @@ jobs:
         id: changed-paths
         run: |
           # Get the list of changed paths
-          changed_paths=$(git diff --name-only main ${{ github.sha }} | grep -E '^dockerfiles/|\.github/workflows/dockerfiles_ci\.yml$' || true)
+          changed_paths=$(git diff --name-only | grep -E '^dockerfiles/|\.github/workflows/dockerfiles_ci\.yml$' || true)
           echo "Changed paths: $changed_paths"
           echo "::set-output name=changed-paths::$changed_paths"
 

--- a/.github/workflows/dockerfiles_ci.yml
+++ b/.github/workflows/dockerfiles_ci.yml
@@ -16,16 +16,38 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Determine changed paths
+        id: changed-paths
+        run: |
+          # Get the list of changed paths
+          changed_paths=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E '^dockerfiles/|\.github/workflows/dockerfiles_ci\.yml$' || true)
+          echo "Changed paths: $changed_paths"
+          echo "::set-output name=changed-paths::$changed_paths"
+
       - name: Build Docker image
         run: |
-          # Loop through each folderectory in the specified directory
-          for folder in dockerfiles/*; do
+          # Split the changed paths into an array
+          IFS=$'\n' read -r -a paths_array <<< "${{ steps.changed-paths.outputs.changed-paths }}"
+
+          # Build all Dockerfile directories if workflow file is changed
+          for path in "${paths_array[@]}"; do
+            if [[ $path == '.github/workflows/dockerfiles_ci.yml' ]]; then
+              for folder in dockerfiles/*; do
+                if [ -d "$folder" ]; then
+                  echo "Building $folder ..."
+                  folder_name=$(basename "$folder")
+                  docker build -t "$folder_name" "$folder"
+                fi
+              done
+              exit 0
+            fi
+          done
+
+          # Build only changed Dockerfile directories
+          for folder in "${paths_array[@]}"; do
             if [ -d "$folder" ]; then
               echo "Building $folder ..."
-              # Extract the last part of the path (folder name)
               folder_name=$(basename "$folder")
-
-              # Build the Docker image with the tag as the folder name
-              docker build -t "$folder_name" "$folder"                  
+              docker build -t "$folder_name" "$folder"
             fi
           done

--- a/.github/workflows/dockerfiles_ci.yml
+++ b/.github/workflows/dockerfiles_ci.yml
@@ -30,6 +30,7 @@ jobs:
           # Check if there is a change in the workflow file
           if [[ $(grep -c '.github/workflows/dockerfiles_ci.yml' <<< "$ALL_CHANGED_FILES") -gt 0 ]]; then
             # Case 1: Build all Dockerfile directories if workflow file is changed
+            echo "Workflow change detected. Building all the dockerfiles..."
             for folder in dockerfiles/*; do
               if [ -d "$folder" ]; then
                 echo "Building $folder ..."
@@ -39,6 +40,7 @@ jobs:
             done
           else
             # Case 2: Build only changed Dockerfile directories
+            echo "Dockerfile directories change detected. Building only related dockerfiles..."
             for folder in ${ALL_CHANGED_FILES}; do
               if [ -d "$folder" ]; then
                 echo "Building $folder ..."

--- a/.github/workflows/dockerfiles_ci.yml
+++ b/.github/workflows/dockerfiles_ci.yml
@@ -20,7 +20,7 @@ jobs:
         id: changed-paths
         run: |
           # Get the list of changed paths
-          changed_paths=$(git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E '^dockerfiles/|\.github/workflows/dockerfiles_ci\.yml$' || true)
+          changed_paths=$(git diff --name-only main ${{ github.sha }} | grep -E '^dockerfiles/|\.github/workflows/dockerfiles_ci\.yml$' || true)
           echo "Changed paths: $changed_paths"
           echo "::set-output name=changed-paths::$changed_paths"
 


### PR DESCRIPTION
Related: #4

## Changes
- ci: detect change paths and run only related docker build
- when workflow file changed, verify all the dockerfiles
- when only component changed, verify docker build on related dockerfiles